### PR TITLE
Use a first-class AdvisorySource

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ With a few important exceptions, these fields correspond _exactly_ (including th
 * Credits support an optional shorthand `"author <author@example.com>"` string format for the common cases where no credit type is assigned and there is only one email-based contact method.
 * References support an optional shorthand string format to just contain the URL itself for the default `"WEB"` reference type.
 * Severities similarly support an optional shorthand string format that contains just CVSS vector itself.
+* Fields with names starting with `jlsec_` are placed into `database_specific` (the the prefix removed).
 
 <details><summary>In practice, a valid JLSEC advisory looks like this:</summary>
 
@@ -44,7 +45,7 @@ ranges = ["<= 1.10.16"]
 pkg = "URIs"
 ranges = ["< 1.6.0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://github.com/JuliaWeb/HTTP.jl/security/advisories/GHSA-4g68-4pxg-mw93"
 id = "GHSA-4g68-4pxg-mw93"
 imported = 2025-09-23T02:06:09.198Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-1.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-1.md
@@ -12,12 +12,12 @@ ranges = ["<= 1.10.16"]
 pkg = "URIs"
 ranges = ["< 1.6.0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://github.com/JuliaWeb/HTTP.jl/security/advisories/GHSA-4g68-4pxg-mw93"
 id = "GHSA-4g68-4pxg-mw93"
-imported = "2025-09-23T02:06:09.198Z"
-modified = "2025-06-24T23:01:25Z"
-published = "2025-06-24T23:01:25Z"
+imported = 2025-09-23T02:06:09.198Z
+modified = 2025-06-24T23:01:25Z
+published = 2025-06-24T23:01:25Z
 url = "https://api.github.com/repos/JuliaWeb/HTTP.jl/security-advisories/GHSA-4g68-4pxg-mw93"
 ```
 
@@ -59,11 +59,11 @@ Users of HTTP.jl should upgrade immediately to HTTP.jl v1.10.17. All prior versi
 
 Users of URIs.jl should upgrade immediately to URIs.jl v1.6.0. All prior versions are vulnerable.
 
-The check for valid URIs is now in the URI.jl package, and the latest version of HTTP.jl incorporates that fix. 
+The check for valid URIs is now in the URI.jl package, and the latest version of HTTP.jl incorporates that fix.
 
 ### Workarounds
 
-Manually validate any URIs before passing them on to functions in this package. 
+Manually validate any URIs before passing them on to functions in this package.
 
 ### References
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-10.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-10.md
@@ -10,12 +10,12 @@ references = ["http://packetstormsecurity.com/files/163978/Git-LFS-Clone-Command
 pkg = "Git_jll"
 ranges = ["< 2.31.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-21300"
 id = "CVE-2021-21300"
-imported = "2025-09-23T02:52:12.921Z"
-modified = "2024-11-21T05:47:58.407Z"
-published = "2021-03-09T20:15:13.260Z"
+imported = 2025-09-23T02:52:12.921Z
+modified = 2024-11-21T05:47:58.407Z
+published = 2021-03-09T20:15:13.260Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-21300"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-11.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-11.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/blob/2dc94da3744bfbbf145eca587a0f5ff48
 pkg = "Git_jll"
 ranges = ["< 2.36.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-24975"
 id = "CVE-2022-24975"
-imported = "2025-09-23T02:52:12.922Z"
-modified = "2024-11-21T06:51:29.247Z"
-published = "2022-02-11T20:15:07.507Z"
+imported = 2025-09-23T02:52:12.922Z
+modified = 2024-11-21T06:51:29.247Z
+published = 2022-02-11T20:15:07.507Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-24975"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-12.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-12.md
@@ -10,12 +10,12 @@ references = ["http://seclists.org/fulldisclosure/2022/May/31", "http://www.open
 pkg = "Git_jll"
 ranges = ["< 2.36.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-24765"
 id = "CVE-2022-24765"
-imported = "2025-09-23T02:52:12.922Z"
-modified = "2024-11-21T06:51:02.873Z"
-published = "2022-04-12T18:15:09.390Z"
+imported = 2025-09-23T02:52:12.922Z
+modified = 2024-11-21T06:51:02.873Z
+published = 2022-04-12T18:15:09.390Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-24765"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-13.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-13.md
@@ -10,12 +10,12 @@ references = ["http://seclists.org/fulldisclosure/2022/Nov/1", "http://www.openw
 pkg = "Git_jll"
 ranges = [">= 2.36.1+0, < 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-29187"
 id = "CVE-2022-29187"
-imported = "2025-09-23T02:52:12.924Z"
-modified = "2024-11-21T06:58:40.120Z"
-published = "2022-07-12T21:15:09.560Z"
+imported = 2025-09-23T02:52:12.924Z
+modified = 2024-11-21T06:58:40.120Z
+published = 2022-07-12T21:15:09.560Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-29187"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-14.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-14.md
@@ -10,12 +10,12 @@ references = ["http://seclists.org/fulldisclosure/2022/Nov/1", "http://www.openw
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-39253"
 id = "CVE-2022-39253"
-imported = "2025-09-23T02:52:12.926Z"
-modified = "2024-11-21T07:17:53.040Z"
-published = "2022-10-19T11:15:11.227Z"
+imported = 2025-09-23T02:52:12.926Z
+modified = 2024-11-21T07:17:53.040Z
+published = 2022-10-19T11:15:11.227Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-39253"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-15.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-15.md
@@ -10,12 +10,12 @@ references = ["http://seclists.org/fulldisclosure/2022/Nov/1", "https://github.c
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-39260"
 id = "CVE-2022-39260"
-imported = "2025-09-23T02:52:12.928Z"
-modified = "2024-11-21T07:17:54.090Z"
-published = "2022-10-19T12:15:10.160Z"
+imported = 2025-09-23T02:52:12.928Z
+modified = 2024-11-21T07:17:54.090Z
+published = 2022-10-19T12:15:10.160Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-39260"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-16.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-16.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git-for-windows/git/commit/7360767e8dfc1895a93
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-41953"
 id = "CVE-2022-41953"
-imported = "2025-09-23T02:52:12.929Z"
-modified = "2024-11-21T07:24:08.677Z"
-published = "2023-01-17T22:15:10.747Z"
+imported = 2025-09-23T02:52:12.929Z
+modified = 2024-11-21T07:24:08.677Z
+published = 2023-01-17T22:15:10.747Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-41953"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-17.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-17.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/commit/508386c6c5857b4faa2c3e491f422c9
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-23521"
 id = "CVE-2022-23521"
-imported = "2025-09-23T02:52:12.931Z"
-modified = "2024-11-21T06:48:44.380Z"
-published = "2023-01-17T23:15:15.580Z"
+imported = 2025-09-23T02:52:12.931Z
+modified = 2024-11-21T06:48:44.380Z
+published = 2023-01-17T23:15:15.580Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-23521"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-18.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-18.md
@@ -10,12 +10,12 @@ references = ["https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#_ex
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-41903"
 id = "CVE-2022-41903"
-imported = "2025-09-23T02:52:12.933Z"
-modified = "2024-11-21T07:24:01.993Z"
-published = "2023-01-17T23:15:15.690Z"
+imported = 2025-09-23T02:52:12.933Z
+modified = 2024-11-21T07:24:01.993Z
+published = 2023-01-17T23:15:15.690Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-41903"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-19.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-19.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/commit/c867e4fa180bec4750e9b54eb10f459
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-22490"
 id = "CVE-2023-22490"
-imported = "2025-09-23T02:52:12.936Z"
-modified = "2024-11-21T07:44:54.803Z"
-published = "2023-02-14T20:15:16.683Z"
+imported = 2025-09-23T02:52:12.936Z
+modified = 2024-11-21T07:44:54.803Z
+published = 2023-02-14T20:15:16.683Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-22490"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-2.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-2.md
@@ -10,12 +10,12 @@ references = ["http://www.openwall.com/lists/oss-security/2024/05/14/2", "https:
 pkg = "Git_jll"
 ranges = ["< 2.46.2+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-32002"
 id = "CVE-2024-32002"
-imported = "2025-09-23T02:52:12.821Z"
-modified = "2024-11-21T09:14:19.267Z"
-published = "2024-05-14T19:15:10.810Z"
+imported = 2025-09-23T02:52:12.821Z
+modified = 2024-11-21T09:14:19.267Z
+published = 2024-05-14T19:15:10.810Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-32002"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-20.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-20.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/commit/c867e4fa180bec4750e9b54eb10f459
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-23946"
 id = "CVE-2023-23946"
-imported = "2025-09-23T02:52:12.942Z"
-modified = "2024-11-21T07:47:09.383Z"
-published = "2023-02-14T20:15:17.457Z"
+imported = 2025-09-23T02:52:12.942Z
+modified = 2024-11-21T07:47:09.383Z
+published = 2023-02-14T20:15:17.457Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-23946"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-21.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-21.md
@@ -10,12 +10,12 @@ references = ["http://www.openwall.com/lists/oss-security/2023/04/25/2", "https:
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-25652"
 id = "CVE-2023-25652"
-imported = "2025-09-23T02:52:12.944Z"
-modified = "2024-11-21T07:49:52.417Z"
-published = "2023-04-25T20:15:09.933Z"
+imported = 2025-09-23T02:52:12.944Z
+modified = 2024-11-21T07:49:52.417Z
+published = 2023-04-25T20:15:09.933Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-25652"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-22.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-22.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/blob/9ce9dea4e1c2419cca126d29fa7730baa
 pkg = "Git_jll"
 ranges = ["< 2.42.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-29007"
 id = "CVE-2023-29007"
-imported = "2025-09-23T02:52:12.947Z"
-modified = "2024-11-21T07:56:22.897Z"
-published = "2023-04-25T21:15:10.403Z"
+imported = 2025-09-23T02:52:12.947Z
+modified = 2024-11-21T07:56:22.897Z
+published = 2023-04-25T21:15:10.403Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-29007"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-23.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-23.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/security/advisories/GHSA-vwqx-4fm8-6qc
 pkg = "Git_jll"
 ranges = ["< 2.51.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2025-48384"
 id = "CVE-2025-48384"
-imported = "2025-09-23T02:52:12.949Z"
-modified = "2025-08-26T14:45:27.957Z"
-published = "2025-07-08T19:15:42.800Z"
+imported = 2025-09-23T02:52:12.949Z
+modified = 2025-08-26T14:45:27.957Z
+published = 2025-07-08T19:15:42.800Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-48384"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-24.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-24.md
@@ -10,12 +10,12 @@ references = ["https://github.com/libgit2/libgit2/releases/tag/v1.6.5", "https:/
 pkg = "LibGit2_jll"
 ranges = ["< 1.7.2+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-24577"
 id = "CVE-2024-24577"
-imported = "2025-09-23T02:52:13.175Z"
-modified = "2024-11-21T08:59:27.603Z"
-published = "2024-02-06T22:16:15.270Z"
+imported = 2025-09-23T02:52:13.175Z
+modified = 2024-11-21T08:59:27.603Z
+published = 2024-02-06T22:16:15.270Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-24577"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-25.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-25.md
@@ -10,12 +10,12 @@ references = ["https://github.com/libgit2/libgit2/commit/add2dabb3c16aa49b33904d
 pkg = "LibGit2_jll"
 ranges = [">= 1.4.3+0, < 1.7.2+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-24575"
 id = "CVE-2024-24575"
-imported = "2025-09-23T02:52:13.176Z"
-modified = "2024-11-21T08:59:27.280Z"
-published = "2024-02-06T22:16:15.057Z"
+imported = 2025-09-23T02:52:13.176Z
+modified = 2024-11-21T08:59:27.280Z
+published = 2024-02-06T22:16:15.057Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-24575"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-26.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-26.md
@@ -10,12 +10,12 @@ references = ["http://www.openwall.com/lists/oss-security/2023/11/06/5", "https:
 pkg = "LibGit2_jll"
 ranges = ["< 1.6.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-22742"
 id = "CVE-2023-22742"
-imported = "2025-09-23T02:52:13.176Z"
-modified = "2024-11-21T07:45:20.250Z"
-published = "2023-01-20T23:15:10.307Z"
+imported = 2025-09-23T02:52:13.176Z
+modified = 2024-11-21T07:45:20.250Z
+published = 2023-01-20T23:15:10.307Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-22742"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-27.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-27.md
@@ -9,12 +9,12 @@ aliases = ["GHSA-w8jv-rg3h-fc68", "CVE-2025-52480"]
 pkg = "Registrator"
 ranges = ["<= 1.9.4"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://github.com/JuliaRegistries/Registrator.jl/security/advisories/GHSA-w8jv-rg3h-fc68"
 id = "GHSA-w8jv-rg3h-fc68"
 imported = 2025-09-23T21:55:52.259Z
-modified = "2025-06-24T23:01:40Z"
-published = "2025-06-24T23:01:40Z"
+modified = 2025-06-24T23:01:40Z
+published = 2025-06-24T23:01:40Z
 url = "https://api.github.com/repos/JuliaRegistries/Registrator.jl/security-advisories/GHSA-w8jv-rg3h-fc68"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-28.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-28.md
@@ -10,7 +10,7 @@ references = ["https://cert-portal.siemens.com/productcert/pdf/ssa-412672.pdf", 
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.1+2"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1552"
 id = "CVE-2019-1552"
 imported = 2025-09-23T21:56:30.605Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-29.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-29.md
@@ -10,7 +10,7 @@ references = ["https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.1+2"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1549"
 id = "CVE-2019-1549"
 imported = 2025-09-23T21:56:30.607Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-3.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-3.md
@@ -10,12 +10,12 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-01/msg0
 pkg = "Git_jll"
 ranges = ["< 2.26.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-19604"
 id = "CVE-2019-19604"
-imported = "2025-09-23T02:52:12.904Z"
-modified = "2024-11-21T04:35:02.160Z"
-published = "2019-12-11T00:15:13.260Z"
+imported = 2025-09-23T02:52:12.904Z
+modified = 2024-11-21T04:35:02.160Z
+published = 2019-12-11T00:15:13.260Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2019-19604"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-30.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-30.md
@@ -10,7 +10,7 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2019-09/msg0
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.1+2"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1547"
 id = "CVE-2019-1547"
 imported = 2025-09-23T21:56:30.607Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-31.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-31.md
@@ -10,7 +10,7 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2019-09/msg0
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.1+2"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1563"
 id = "CVE-2019-1563"
 imported = 2025-09-23T21:56:30.608Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-32.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-32.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.1+2"]
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1551"
 id = "CVE-2019-1551"
 imported = 2025-09-23T21:56:30.609Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-33.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-33.md
@@ -10,7 +10,7 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-07/msg0
 pkg = "OpenSSL_jll"
 ranges = [">= 1.1.1+2, < 1.1.10+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2020-1967"
 id = "CVE-2020-1967"
 imported = 2025-09-23T21:56:31.017Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-34.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-34.md
@@ -10,7 +10,7 @@ references = ["https://lists.debian.org/debian-lts-announce/2020/09/msg00016.htm
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2020-1968"
 id = "CVE-2020-1968"
 imported = 2025-09-23T21:56:31.018Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-35.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-35.md
@@ -10,7 +10,7 @@ references = ["https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf", 
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-23839"
 id = "CVE-2021-23839"
 imported = 2025-09-23T21:56:31.019Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-36.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-36.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.10+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2020-1971"
 id = "CVE-2020-1971"
 imported = 2025-09-23T21:56:31.019Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-37.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-37.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.10+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-23840"
 id = "CVE-2021-23840"
 imported = 2025-09-23T21:56:31.020Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-38.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-38.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.10+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-23841"
 id = "CVE-2021-23841"
 imported = 2025-09-23T21:56:31.021Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-39.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-39.md
@@ -10,7 +10,7 @@ references = ["http://www.openwall.com/lists/oss-security/2021/03/27/1", "http:/
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.10+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-3449"
 id = "CVE-2021-3449"
 imported = 2025-09-23T21:56:31.023Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-4.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-4.md
@@ -10,12 +10,12 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-01/msg0
 pkg = "Git_jll"
 ranges = ["< 2.26.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1387"
 id = "CVE-2019-1387"
-imported = "2025-09-23T02:52:12.906Z"
-modified = "2024-11-21T04:36:36.370Z"
-published = "2019-12-18T21:15:13.820Z"
+imported = 2025-09-23T02:52:12.906Z
+modified = 2024-11-21T04:36:36.370Z
+published = 2019-12-18T21:15:13.820Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2019-1387"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-40.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-40.md
@@ -10,7 +10,7 @@ references = ["http://www.openwall.com/lists/oss-security/2021/08/26/2", "https:
 pkg = "OpenSSL_jll"
 ranges = ["< 1.1.13+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-3711"
 id = "CVE-2021-3711"
 imported = 2025-09-23T21:56:31.024Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-41.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-41.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.13+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.19.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-3712"
 id = "CVE-2021-3712"
 imported = 2025-09-23T21:56:31.025Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-42.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-42.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.13+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.21.4+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-4160"
 id = "CVE-2021-4160"
 imported = 2025-09-23T21:56:31.078Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-43.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-43.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.14+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.21.4+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-0778"
 id = "CVE-2022-0778"
 imported = 2025-09-23T21:56:31.080Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-44.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-44.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.16+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.21.4+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-1292"
 id = "CVE-2022-1292"
 imported = 2025-09-23T21:56:31.081Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-45.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-45.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.16+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.21.4+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-2068"
 id = "CVE-2022-2068"
 imported = 2025-09-23T21:56:31.084Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-46.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-46.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.17+0"]
 pkg = "Openresty_jll"
 ranges = [">= 1.19.9+0, < 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-2097"
 id = "CVE-2022-2097"
 imported = 2025-09-23T21:56:31.085Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-47.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-47.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.20+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-4304"
 id = "CVE-2022-4304"
 imported = 2025-09-23T21:56:31.088Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-48.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-48.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.20+0"]
 pkg = "Openresty_jll"
 ranges = [">= 1.19.9+0, < 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2022-4450"
 id = "CVE-2022-4450"
 imported = 2025-09-23T21:56:31.089Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-49.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-49.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.20+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-0215"
 id = "CVE-2023-0215"
 imported = 2025-09-23T21:56:31.090Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-5.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-5.md
@@ -10,12 +10,12 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-01/msg0
 pkg = "Git_jll"
 ranges = ["< 2.26.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1348"
 id = "CVE-2019-1348"
-imported = "2025-09-23T02:52:12.909Z"
-modified = "2024-11-21T04:36:31.990Z"
-published = "2020-01-24T22:15:19.190Z"
+imported = 2025-09-23T02:52:12.909Z
+modified = 2024-11-21T04:36:31.990Z
+published = 2020-01-24T22:15:19.190Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2019-1348"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-50.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-50.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.20+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-0286"
 id = "CVE-2023-0286"
 imported = 2025-09-23T21:56:31.092Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-51.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-51.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.21+0", ">= 3.0.8+0, < 3.0.9+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-0464"
 id = "CVE-2023-0464"
 imported = 2025-09-23T21:56:31.094Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-52.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-52.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.21+0", ">= 3.0.8+0, < 3.0.9+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-0465"
 id = "CVE-2023-0465"
 imported = 2025-09-23T21:56:31.095Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-53.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-53.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.21+0", ">= 3.0.8+0, < 3.0.9+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-0466"
 id = "CVE-2023-0466"
 imported = 2025-09-23T21:56:31.096Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-54.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-54.md
@@ -10,7 +10,7 @@ references = ["https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=02ac
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.9+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-1255"
 id = "CVE-2023-1255"
 imported = 2025-09-23T21:56:31.097Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-55.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-55.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.21+0", ">= 3.0.8+0, < 3.0.9+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-2650"
 id = "CVE-2023-2650"
 imported = 2025-09-23T21:56:31.098Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-56.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-56.md
@@ -10,7 +10,7 @@ references = ["https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=00e2
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.10+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-2975"
 id = "CVE-2023-2975"
 imported = 2025-09-23T21:56:31.099Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-57.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-57.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.22+0", ">= 3.0.8+0, < 3.0.10+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-3817"
 id = "CVE-2023-3817"
 imported = 2025-09-23T21:56:31.115Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-58.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-58.md
@@ -10,7 +10,7 @@ references = ["https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=0df4
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.12+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-5363"
 id = "CVE-2023-5363"
 imported = 2025-09-23T21:56:31.116Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-59.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-59.md
@@ -13,7 +13,7 @@ ranges = ["< 1.1.23+0", ">= 3.0.8+0, < 3.0.11+0"]
 pkg = "Openresty_jll"
 ranges = [">= 1.19.9+0, < 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-4807"
 id = "CVE-2023-4807"
 imported = 2025-09-23T21:56:31.116Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-6.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-6.md
@@ -10,12 +10,12 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-01/msg0
 pkg = "Git_jll"
 ranges = ["< 2.26.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2019-1353"
 id = "CVE-2019-1353"
-imported = "2025-09-23T02:52:12.911Z"
-modified = "2024-11-21T04:36:32.663Z"
-published = "2020-01-24T22:15:19.253Z"
+imported = 2025-09-23T02:52:12.911Z
+modified = 2024-11-21T04:36:32.663Z
+published = 2020-01-24T22:15:19.253Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2019-1353"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-60.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-60.md
@@ -13,7 +13,7 @@ ranges = ["< 3.0.13+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-5678"
 id = "CVE-2023-5678"
 imported = 2025-09-23T21:56:31.118Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-61.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-61.md
@@ -10,7 +10,7 @@ references = ["https://github.com/openssl/openssl/commit/050d26383d4e264966fb834
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.13+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-6129"
 id = "CVE-2023-6129"
 imported = 2025-09-23T21:56:31.118Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-62.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-62.md
@@ -13,7 +13,7 @@ ranges = ["< 3.0.13+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-0727"
 id = "CVE-2024-0727"
 imported = 2025-09-23T21:56:31.120Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-63.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-63.md
@@ -10,7 +10,7 @@ references = ["https://github.com/openssl/openssl/commit/05f360d9e849a1b277db628
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.15+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-6119"
 id = "CVE-2024-6119"
 imported = 2025-09-23T21:56:31.121Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-64.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-64.md
@@ -10,21 +10,22 @@ references = ["https://github.com/openssl/openssl/commit/e96d22446e633d117e6c990
 pkg = "OpenSSL_jll"
 ranges = [">= 3.5.0+0, < 3.5.1+0"]
 
-[database_specific.affected_source]
-html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-16129"
-id = "EUVD-2025-16129"
-imported = 2025-09-23T21:56:31.345Z
-modified = 2025-05-22T18:31:15.000Z
-published = 2025-05-22T15:34:50.000Z
-url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2025-16129"
-
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2025-4575"
 id = "CVE-2025-4575"
 imported = 2025-09-23T21:56:31.344Z
 modified = 2025-05-23T15:55:02.040Z
 published = 2025-05-22T14:16:07.630Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-4575"
+
+[[jlsec_sources]]
+html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-16129"
+id = "EUVD-2025-16129"
+imported = 2025-09-23T21:56:31.345Z
+modified = 2025-05-22T18:31:15.000Z
+published = 2025-05-22T15:34:50.000Z
+url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2025-16129"
+fields = ["affected"]
 ```
 
 # Issue summary: Use of -addreject option with the openssl x509 application adds a trusted use instead...

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-65.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-65.md
@@ -13,21 +13,22 @@ ranges = ["< 3.0.15+0"]
 pkg = "Openresty_jll"
 ranges = ["< 1.27.1+0"]
 
-[database_specific.affected_source]
-html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-46737"
-id = "EUVD-2024-46737"
-imported = 2025-09-23T21:56:31.486Z
-modified = 2025-02-13T17:54:20.000Z
-published = 2024-06-27T10:30:53.000Z
-url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-46737"
-
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-5535"
 id = "CVE-2024-5535"
 imported = 2025-09-23T21:56:31.484Z
 modified = 2025-09-01T09:15:34.120Z
 published = 2024-06-27T11:15:24.447Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-5535"
+
+[[jlsec_sources]]
+html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-46737"
+id = "EUVD-2024-46737"
+imported = 2025-09-23T21:56:31.486Z
+modified = 2025-02-13T17:54:20.000Z
+published = 2024-06-27T10:30:53.000Z
+url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-46737"
+fields = ["affected"]
 ```
 
 # Issue summary: Calling the OpenSSL API function SSL*select*next_proto with an empty supported client...

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-66.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-66.md
@@ -13,21 +13,22 @@ ranges = ["< 3.0.14+0"]
 pkg = "Openresty_jll"
 ranges = [">= 1.19.9+0, < 1.27.1+0"]
 
-[database_specific.affected_source]
-html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-44338"
-id = "EUVD-2024-44338"
-imported = 2025-09-23T21:56:31.488Z
-modified = 2024-11-13T14:49:05.000Z
-published = 2024-11-13T10:20:50.000Z
-url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-44338"
-
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-4741"
 id = "CVE-2024-4741"
 imported = 2025-09-23T21:56:31.486Z
 modified = 2024-11-13T17:01:16.850Z
 published = 2024-11-13T11:15:04.480Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-4741"
+
+[[jlsec_sources]]
+html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-44338"
+id = "EUVD-2024-44338"
+imported = 2025-09-23T21:56:31.488Z
+modified = 2024-11-13T14:49:05.000Z
+published = 2024-11-13T10:20:50.000Z
+url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-44338"
+fields = ["affected"]
 ```
 
 # Issue summary: Calling the OpenSSL API function SSL*free*buffers may cause memory to be accessed tha...

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-67.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-67.md
@@ -10,21 +10,22 @@ references = ["https://github.com/openssl/openssl/commit/0b0f7abfb37350794a4b896
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.13+0"]
 
-[database_specific.affected_source]
-html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2023-58483"
-id = "EUVD-2023-58483"
-imported = 2025-09-23T21:56:31.515Z
-modified = 2024-11-01T14:28:51.000Z
-published = 2024-04-25T06:27:26.000Z
-url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2023-58483"
-
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2023-6237"
 id = "CVE-2023-6237"
 imported = 2025-09-23T21:56:31.490Z
 modified = 2024-11-21T08:43:25.997Z
 published = 2024-04-25T07:15:45.270Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2023-6237"
+
+[[jlsec_sources]]
+html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2023-58483"
+id = "EUVD-2023-58483"
+imported = 2025-09-23T21:56:31.515Z
+modified = 2024-11-01T14:28:51.000Z
+published = 2024-04-25T06:27:26.000Z
+url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2023-58483"
+fields = ["affected"]
 ```
 
 # Issue summary: Checking excessively long invalid RSA public keys may take

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-68.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-68.md
@@ -10,21 +10,22 @@ references = ["https://github.com/openssl/openssl/commit/3559e868e58005d15c6013a
 pkg = "OpenSSL_jll"
 ranges = [">= 3.0.8+0, < 3.0.14+0"]
 
-[database_specific.affected_source]
-html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-44212"
-id = "EUVD-2024-44212"
-imported = 2025-09-23T21:56:31.540Z
-modified = 2024-10-14T14:56:01.000Z
-published = 2024-05-16T15:21:20.000Z
-url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-44212"
-
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2024-4603"
 id = "CVE-2024-4603"
 imported = 2025-09-23T21:56:31.539Z
 modified = 2024-11-21T09:43:11.753Z
 published = 2024-05-16T16:15:10.643Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2024-4603"
+
+[[jlsec_sources]]
+html_url = "https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-44212"
+id = "EUVD-2024-44212"
+imported = 2025-09-23T21:56:31.540Z
+modified = 2024-10-14T14:56:01.000Z
+published = 2024-05-16T15:21:20.000Z
+url = "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-44212"
+fields = ["affected"]
 ```
 
 # Issue summary: Checking excessively long DSA keys or parameters may be very

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-69.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-69.md
@@ -16,7 +16,7 @@ ranges = ["< 0.3.20+0"]
 pkg = "OpenBLASHighCoreCount_jll"
 ranges = ["*"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-4048"
 id = "CVE-2021-4048"
 imported = 2025-09-24T14:36:01.885Z

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-7.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-7.md
@@ -10,12 +10,12 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-04/msg0
 pkg = "Git_jll"
 ranges = ["< 2.26.1+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2020-5260"
 id = "CVE-2020-5260"
-imported = "2025-09-23T02:52:12.915Z"
-modified = "2024-11-21T05:33:47.230Z"
-published = "2020-04-14T23:15:12.607Z"
+imported = 2025-09-23T02:52:12.915Z
+modified = 2024-11-21T05:33:47.230Z
+published = 2020-04-14T23:15:12.607Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2020-5260"
 ```
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-8.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-8.md
@@ -10,18 +10,18 @@ references = ["http://lists.opensuse.org/opensuse-security-announce/2020-05/msg0
 pkg = "Git_jll"
 ranges = ["< 2.27.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2020-11008"
 id = "CVE-2020-11008"
-imported = "2025-09-23T02:52:12.917Z"
-modified = "2024-11-21T04:56:34.263Z"
-published = "2020-04-21T19:15:13.457Z"
+imported = 2025-09-23T02:52:12.917Z
+modified = 2024-11-21T04:56:34.263Z
+published = 2020-04-21T19:15:13.457Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2020-11008"
 ```
 
 # Git could be tricked to send private credentials to an external host
 
-Affected versions of Git have a vulnerability whereby Git can be tricked into sending private credentials to a host controlled by an attacker. This bug is similar to [CVE-2020-5260](GHSA-qm7j-c969-7j4q). The fix for that bug still left the door open for an exploit where *some* credential is leaked (but the attacker cannot control which one). Git uses external "credential helper" programs to store and retrieve passwords or other credentials from secure storage provided by the operating system. Specially-crafted URLs that are considered illegal as of the recently published Git versions can cause Git to send a "blank" pattern to helpers, missing hostname and protocol fields. Many helpers will interpret this as matching *any* URL, and will return some unspecified stored password, leaking the password to an attacker's server. The vulnerability can be triggered by feeding a malicious URL to `git clone`. However, the affected URLs look rather suspicious; the likely vector would be through systems which automatically clone URLs not visible to the user, such as Git submodules, or package systems built around Git. The root of the problem is in Git itself, which should not be feeding blank input to helpers. However, the ability to exploit the vulnerability in practice depends on which helpers are in use. 
+Affected versions of Git have a vulnerability whereby Git can be tricked into sending private credentials to a host controlled by an attacker. This bug is similar to [CVE-2020-5260](GHSA-qm7j-c969-7j4q). The fix for that bug still left the door open for an exploit where *some* credential is leaked (but the attacker cannot control which one). Git uses external "credential helper" programs to store and retrieve passwords or other credentials from secure storage provided by the operating system. Specially-crafted URLs that are considered illegal as of the recently published Git versions can cause Git to send a "blank" pattern to helpers, missing hostname and protocol fields. Many helpers will interpret this as matching *any* URL, and will return some unspecified stored password, leaking the password to an attacker's server. The vulnerability can be triggered by feeding a malicious URL to `git clone`. However, the affected URLs look rather suspicious; the likely vector would be through systems which automatically clone URLs not visible to the user, such as Git submodules, or package systems built around Git. The root of the problem is in Git itself, which should not be feeding blank input to helpers. However, the ability to exploit the vulnerability in practice depends on which helpers are in use.
 
 Credential helpers which are known to trigger the vulnerability:
 
@@ -29,7 +29,7 @@ Credential helpers which are known to trigger the vulnerability:
   * Git's "cache" helper
   * the "osxkeychain" helper that ships in Git's "contrib" directory
 
-Credential helpers which are known to be safe even with vulnerable versions of Git: 
+Credential helpers which are known to be safe even with vulnerable versions of Git:
 
   * Git Credential Manager for Windows Any helper not in this list should be assumed to trigger the vulnerability.
 

--- a/advisories/published/2025/DONOTUSEJLSEC-2025-9.md
+++ b/advisories/published/2025/DONOTUSEJLSEC-2025-9.md
@@ -10,12 +10,12 @@ references = ["https://github.com/git/git/commit/a02ea577174ab8ed18f847cf1693f21
 pkg = "Git_jll"
 ranges = ["< 2.31.0+0"]
 
-[database_specific.source]
+[[jlsec_sources]]
 html_url = "https://nvd.nist.gov/vuln/detail/CVE-2021-40330"
 id = "CVE-2021-40330"
-imported = "2025-09-23T02:52:12.921Z"
-modified = "2024-11-21T06:23:52.550Z"
-published = "2021-08-31T04:15:10.667Z"
+imported = 2025-09-23T02:52:12.921Z
+modified = 2024-11-21T06:23:52.550Z
+published = 2021-08-31T04:15:10.667Z
 url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2021-40330"
 ```
 

--- a/src/EUVD.jl
+++ b/src/EUVD.jl
@@ -6,7 +6,7 @@ using Dates: Dates, DateTime, @dateformat_str
 using TOML: TOML
 using DataStructures: OrderedDict as Dict # watch out
 
-using ..SecurityAdvisories: SecurityAdvisories, exists, Reference, Severity, Advisory, extract_summary
+using ..SecurityAdvisories: SecurityAdvisories, exists, Reference, Severity, Advisory, AdvisorySource, extract_summary
 
 # https://euvd.enisa.europa.eu/apidoc
 const API_BASE = "https://euvdservices.enisa.europa.eu/api"
@@ -167,16 +167,15 @@ function advisory(vuln)
         affected = affected,
         references = [Reference(url=ref) for ref in split(get(vuln, :references, ""), "\n"; keepempty=false)],
         # credits -- not structured
-        database_specific = Dict{String,Any}("source" => Dict(
-            "id" => vuln.id,
-            "modified" => if exists(vuln, :dateUpdated) parse_euvd_datetime(vuln.dateUpdated) end,
-            "published" => if exists(vuln, :datePublished) parse_euvd_datetime(vuln.datePublished) end,
-            "imported" => Dates.now(Dates.UTC),
-            "url" => string(API_BASE, "/enisaid?id=", vuln.id),
-            "html_url" => string("https://euvd.enisa.europa.eu/vulnerability/", vuln.id)
-            )
+        jlsec_sources = [AdvisorySource(;
+            id = vuln.id,
+            modified = if exists(vuln, :dateUpdated) parse_euvd_datetime(vuln.dateUpdated) end,
+            published = if exists(vuln, :datePublished) parse_euvd_datetime(vuln.datePublished) end,
+            imported = Dates.now(Dates.UTC),
+            url = string(API_BASE, "/enisaid?id=", vuln.id),
+            html_url = string("https://euvd.enisa.europa.eu/vulnerability/", vuln.id)
+            )]
         )
-    )
 end
 
 end

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -5,7 +5,7 @@ using JSON3
 using Dates
 using DataStructures: OrderedDict as Dict # watch out
 
-using ..SecurityAdvisories: SecurityAdvisories, exists, VersionRange, VersionString, Credit, Reference, Severity, Advisory
+using ..SecurityAdvisories: SecurityAdvisories, exists, VersionRange, VersionString, Credit, Reference, Severity, Advisory, AdvisorySource
 
 const GITHUB_API_BASE = "https://api.github.com"
 const DEFAULT_HOURS = 25
@@ -269,16 +269,15 @@ function advisory(vuln)
         affected = affected,
         references = [Reference(url=ref) for ref in something(get(vuln, :references, nothing), [])],
         credits = credits,
-        database_specific = Dict{String,Any}("source" => Dict(
-            "id" => vuln.ghsa_id,
-            "modified" => vuln.updated_at,
-            "published" => vuln.published_at,
-            "imported" => Dates.now(Dates.UTC),
-            "url" => vuln.url,
-            "html_url" => vuln.html_url
-            )
+        jlsec_sources = [AdvisorySource(;
+            id = vuln.ghsa_id,
+            modified = Dates.DateTime(chopsuffix(vuln.updated_at, "Z")),
+            published = Dates.DateTime(chopsuffix(vuln.published_at, "Z")),
+            imported = Dates.now(Dates.UTC),
+            url = vuln.url,
+            html_url = vuln.html_url
+            )]
         )
-    )
 end
 
 

--- a/src/NVD.jl
+++ b/src/NVD.jl
@@ -6,7 +6,7 @@ using Dates
 using TOML: TOML
 using DataStructures: OrderedDict as Dict # watch out
 
-using ..SecurityAdvisories: SecurityAdvisories, exists, Severity, Advisory, Reference, Credit, extract_summary
+using ..SecurityAdvisories: SecurityAdvisories, exists, Severity, Advisory, Reference, Credit, AdvisorySource, extract_summary
 
 const NVD_API_BASE = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 const NVD_CPE_API_BASE = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
@@ -296,16 +296,15 @@ function advisory(vuln)
         affected = affected,
         references = [Reference(url=ref.url) for ref in get(vuln.cve, :references, []) if haskey(ref, :url)],
         # credits -- not structured
-        database_specific = Dict{String,Any}("source" => Dict(
-            "id" => vuln.cve.id,
-            "modified" => Dates.DateTime(vuln.cve.lastModified),
-            "published" => Dates.DateTime(vuln.cve.published),
-            "imported" => Dates.now(Dates.UTC),
-            "url" => string(NVD_API_BASE, "?cveId=", vuln.cve.id),
-            "html_url" => string("https://nvd.nist.gov/vuln/detail/", vuln.cve.id)
-            )
+        jlsec_sources = [AdvisorySource(;
+            id = vuln.cve.id,
+            modified = Dates.DateTime(vuln.cve.lastModified),
+            published = Dates.DateTime(vuln.cve.published),
+            imported = Dates.now(Dates.UTC),
+            url = string(NVD_API_BASE, "?cveId=", vuln.cve.id),
+            html_url = string("https://nvd.nist.gov/vuln/detail/", vuln.cve.id)
+            )]
         )
-    )
 end
 
 end

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -116,6 +116,18 @@ function Base.tryparse(::Type{Severity}, score)
     return Severity(type, String(score))
 end
 
+@kwdef struct AdvisorySource
+    id::String
+    imported::DateTime
+    modified::DateTime
+    published::DateTime
+    url::String
+    html_url::String
+    fields::Vector{String} = String[] # An optional subset of fields that were updated by this source (excepting alias/upstream)
+end
+Base.:(==)(a::AdvisorySource, b::AdvisorySource) = to_toml_frontmatter(a) == to_toml_frontmatter(b)
+Base.hash(a::AdvisorySource, h::UInt) = hash(to_toml_frontmatter(a), hash(0xa3a999db00b21f4d, h))
+
 """
     Advisory(; osv_kwargs...)
 
@@ -141,9 +153,11 @@ There is just one place where we differ:
     affected::Vector{PackageVulnerability} = PackageVulnerability[]
     references::Vector{Reference} = Reference[]
     credits::Vector{Credit} = Credit[]
-    ## JULSEC-specific fields
-    database_specific::Dict{String,Any} = Dict{String,Any}() # TODO: define these fields?
+    ## JLSEC database_specific fields:
+    jlsec_sources::Vector{AdvisorySource} = AdvisorySource[]
 end
+osv_fieldnames(::Type{Advisory}) = filter(!startswith("jlsec_")∘string, fieldnames(Advisory))
+database_specific_fieldnames(::Type{Advisory}) = filter(startswith("jlsec_")∘string, fieldnames(Advisory))
 # Advisory identity is purely determined by the serialization format
 function Base.:(==)(a::Advisory, b::Advisory)
     return to_toml_frontmatter(a) == to_toml_frontmatter(b) && a.summary == b.summary && a.details == b.details
@@ -182,7 +196,7 @@ function update(original::Advisory, updates::Advisory)
         affected = new.affected,
         references = new.references,
         credits = new.credits,
-        database_specific = new.database_specific,
+        sources = new.sources,
     )
 end
 
@@ -198,9 +212,9 @@ Recursively convert an Advisory and all its fields (except `summary` and `detail
 """
 to_toml_frontmatter(v::Union{VersionNumber, VersionString, VersionRange}) = string(v)
 to_toml_frontmatter(x::Union{AbstractString, Integer, AbstractFloat, Bool, Dates.DateTime, Dates.Time, Dates.Date}) = x
-to_toml_frontmatter(d::OrderedDict) = OrderedDict(k=>to_toml_frontmatter_collection(v, values(d)) for (k,v) in d)
-to_toml_frontmatter(d::AbstractDict) = sort(OrderedDict(k=>to_toml_frontmatter_collection(v, values(d)) for (k,v) in d))
+to_toml_frontmatter(d::AbstractDict) = OrderedDict(k=>to_toml_frontmatter_collection(v, values(d)) for (k,v) in d)
 to_toml_frontmatter(A::AbstractArray) = [to_toml_frontmatter_collection(x, A) for x in A]
+to_toml_frontmatter(s::AdvisorySource) = OrderedDict(string(f) => to_toml_frontmatter(getproperty(s, f)) for f in fieldnames(AdvisorySource) if is_populated(getfield(s, f)))
 to_toml_frontmatter_collection(x, _) = to_toml_frontmatter(x)
 function to_toml_frontmatter(a::Advisory)
     # Convert all fields to TOML with a few special cases:
@@ -292,8 +306,16 @@ to_osv_dict(x::Dates.DateTime) = chopsuffix(string(x), "Z") * "Z" # All times sh
 to_osv_dict(x::Union{AbstractString, Integer, AbstractFloat, Bool}) = x
 to_osv_dict(d::AbstractDict) = OrderedDict(string(k)=>to_osv_dict(v) for (k,v) in d)
 to_osv_dict(A::AbstractArray) = [to_osv_dict(v) for v in A]
-function to_osv_dict(a::Union{Advisory, Severity, Reference, Credit})
+function to_osv_dict(a::Union{Severity, Reference, Credit, AdvisorySource})
     return OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in fieldnames(typeof(a)) if is_populated(getproperty(a, f)))
+end
+function to_osv_dict(a::Advisory)
+    # The only special thing we need to do here is collect the database_specific fields
+    d = OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in osv_fieldnames(Advisory) if is_populated(getproperty(a, f)))
+    if any(is_populated, (getproperty(a, f) for f in database_specific_fieldnames(Advisory)))
+        d["database_specific"] = OrderedDict(chopprefix(string(f), "jlsec_") => to_osv_dict(getproperty(a, f)) for f in database_specific_fieldnames(Advisory))
+    end
+    return d
 end
 # Package vulnerabilities are the one thing we store quite differently:
 function to_osv_dict(vuln::PackageVulnerability)

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -127,6 +127,7 @@ end
 end
 Base.:(==)(a::AdvisorySource, b::AdvisorySource) = to_toml_frontmatter(a) == to_toml_frontmatter(b)
 Base.hash(a::AdvisorySource, h::UInt) = hash(to_toml_frontmatter(a), hash(0xa3a999db00b21f4d, h))
+Base.convert(::Type{AdvisorySource}, d::AbstractDict) = AdvisorySource(; Dict(Symbol(k)=>v for (k,v) in d)...)
 
 """
     Advisory(; osv_kwargs...)
@@ -288,11 +289,11 @@ function Base.tryparse(::Type{Advisory}, s::Union{AbstractString, IO})
         Markdown.plain(m[2+!isnothing(summary):end])
     end
 
-    return try
+    # return try
         Advisory(; Dict(Symbol(k)=>v for (k,v) in frontmatter)..., summary, details)
-    catch _
-        nothing
-    end
+    # catch _
+    #     nothing
+    # end
 end
 
 """


### PR DESCRIPTION
Establish the convention of having `jlsec_` fields for database specific ones. Store the sources in a vector that represents the sequence of events from which the JLSEC advisory was cobbled together. Use an optional `fields` to represent only updating some subset of fields. This should help with round-trippability, fix the issues with string/DateTime timestamps, and hopefully make it easier to avoid clobbering our updates if the upstream source has not changed since our last import.